### PR TITLE
Allow to set SMTP stream SSL options via config

### DIFF
--- a/src/Tasks/EmailTaskProcessor.php
+++ b/src/Tasks/EmailTaskProcessor.php
@@ -26,6 +26,10 @@ class EmailTaskProcessor implements ItemProcessor
             ->setUsername($smtpSettings['username'])
             ->setPassword($smtpSettings['password']);
 
+        if (isset($smtpSettings['streamOptions'])) {
+            $transport->setStreamOptions($smtpSettings['streamOptions']);
+        }
+
         $mailer = new Swift_Mailer($transport);
 
         try {


### PR DESCRIPTION
This change allows to add SSL stream configation options to the
smtp section of the config file.

Example:

```
"smtp": [
    "streamOptions": [
      "ssl": [
          "allow_self_signed": true,
          "verify_peer": false,
          "verify_peer_name": false
      ]
    ]
]
```