### PR TITLE
Added examples into reports

### DIFF
--- a/src/Controllers/Reports/CreateReportController.php
+++ b/src/Controllers/Reports/CreateReportController.php
@@ -81,6 +81,12 @@ class CreateReportController extends Controller
                 $template->setValue($key, $value);
             }
 
+            $attachments = $vars['project']['attachments'];
+            $template->cloneBlock('attachments', count($attachments), true, true);
+            foreach ($attachments as $index => $attach) {
+                $template->setImageValue('attachment.image#' . ($index + 1), $attach);
+            }
+
             try {
                 $template->cloneRow('user.full_name', count($vars['users']), true, true);
                 foreach ($vars['users'] as $index => $user) {
@@ -144,7 +150,7 @@ class CreateReportController extends Controller
             }
 
             $markdownParser = new GithubFlavoredMarkdownConverter();
-            $word = new PhpWord();
+            $word = new PhpWord();            
 
             try {
                 $template->cloneBlock('vulnerabilities', count($vars['vulnerabilities']), true, true);
@@ -159,6 +165,13 @@ class CreateReportController extends Controller
                         Html::addHtml($cell, $description);
 
                         $template->setComplexBlock('vulnerability.description#' . ($index + 1), $tempTable);
+                    }
+
+                    $attachments = $vulnerability['attachments'];
+                    $template->cloneBlock('vulnerability.attachments#' . ($index + 1), count($attachments), true, true);
+                    foreach ($attachments as $i => $attach) {
+                        $name = 'vulnerability.attachment.image#' . ($index + 1) . "#" . ($i + 1);
+                        $template->setImageValue($name, $attach);
                     }
 
                     $template->setValue('vulnerability.category_name#' . ($index + 1), $vulnerability['category_name']);

--- a/src/Services/Reporting/ReportDataCollector.php
+++ b/src/Services/Reporting/ReportDataCollector.php
@@ -60,6 +60,17 @@ class ReportDataCollector
             $vulnerability_sort = "FIELD(v.owasp_overall, 'critical','high','medium','low','note')";
         }
         $vulnerabilities = $this->vulnerabilityRepository->search($vulnerabilitySearchCriteria, null, $vulnerability_sort);
+        foreach ($vulnerabilities as $key => $vuln) {
+            $pngs = $projectAttachments = $this->attachmentRepository->findByParentId('vulnerability', $vuln['id'], 'image/png');
+            $jpegs = $projectAttachments = $this->attachmentRepository->findByParentId('vulnerability', $vuln['id'], 'image/jpeg');
+            $gifs = $projectAttachments = $this->attachmentRepository->findByParentId('vulnerability', $vuln['id'], 'image/gif');
+            $attachments = array_merge($pngs, $jpegs, $gifs);
+            $att = [];
+            foreach ($attachments as $k => $value) {
+                $att[$k] = $this->attachmentFilePathService->generateFilePath($value['file_name']);
+            }
+            $vulnerabilities[$key]['attachments'] = $att;
+        }
 
         $reports = $this->reportRepository->findByProjectId($projectId);
 
@@ -106,6 +117,16 @@ class ReportDataCollector
         $vaultSearchCriteria = new VaultSearchCriteria();
         $vaultSearchCriteria->addReportableProjectCriterion($projectId);
         $vaultItems = $this->vaultRepository->search($vaultSearchCriteria);
+
+        $pngs = $this->attachmentRepository->findByParentId('project', $projectId, 'image/png');
+        $jpegs = $this->attachmentRepository->findByParentId('project', $projectId, 'image/jpeg');
+        $gifs = $this->attachmentRepository->findByParentId('project', $projectId, 'image/gif');
+        $attachments = array_merge($pngs, $jpegs, $gifs);
+        $att = [];
+        foreach ($attachments as $k => $value) {
+            $att[$k] = $this->attachmentFilePathService->generateFilePath($value['file_name']);
+        }
+        $project['attachments'] = $att;
 
         $vars = [
             'configuration' => $configuration,

--- a/tests/Controllers/Reports/CreateReportControllerTest.php
+++ b/tests/Controllers/Reports/CreateReportControllerTest.php
@@ -70,7 +70,7 @@ class CreateReportControllerTest extends TestCase
         $controller->setLogger($this->createMock(Logger::class));
         $response = $controller($mockRequest);
 
-        $expectedAttachmentIds = [0];
+        $expectedAttachmentIds = [];
 
         $this->assertEquals($expectedAttachmentIds, $response);
     }

--- a/tests/Services/Reporting/ReportDataCollectorTest.php
+++ b/tests/Services/Reporting/ReportDataCollectorTest.php
@@ -77,7 +77,9 @@ class ReportDataCollectorTest extends TestCase
         $result = $dataCollector->collectForProject(0);
 
         $expectedResult = ['configuration' => $reportConfiguration,
-            'project' => array(),
+            'project' => array(
+                'attachments' => array()
+            ),
             'org' => null,
             'date' => date('Y-m-d'),
             'reports' => array(),


### PR DESCRIPTION
I one more time slightly enhanced the report. 

1. I added a capability to load images from attachments to each vulnerability and also to the project.
1.1 Vulnerabilities and images
<img width="515" alt="image" src="https://user-images.githubusercontent.com/2551605/161761170-61c007ea-77f7-4844-8472-5684462db4eb.png">
<img width="622" alt="image" src="https://user-images.githubusercontent.com/2551605/161761071-8cb8ceef-8254-48f3-bd98-43db8f53e569.png">
1.2 Project attachments (only images for now)
<img width="666" alt="image" src="https://user-images.githubusercontent.com/2551605/161761306-bb45bec8-72cf-404e-8e2c-9014e0ab81ba.png">
<img width="537" alt="image" src="https://user-images.githubusercontent.com/2551605/161761387-6a54080a-c182-4e94-8ce1-1d8d670435f8.png">


2. I updated how PoC of vulnerability is propagated into the ouput. I am using MD parser to generate the HTML, but I am not inserting it directly into the PHPWord as in case of description. Instead of it, I use XPath to extract all `<code>` elements and I parse these manually. 
This approach has one benefit, PoC can have more examples and all of them are in the output and parsed differently. The con is, that it strips another elements. 

<img width="517" alt="image" src="https://user-images.githubusercontent.com/2551605/161762002-78a059d1-2dcc-4250-8565-111fda587ca1.png">
<img width="634" alt="image" src="https://user-images.githubusercontent.com/2551605/161762081-c96b3d53-276e-4427-886d-2a6b1aad237e.png">

# generate doc and template
[template.docx](https://github.com/reconmap/rest-api/files/8418386/template.docx)
[test.docx](https://github.com/reconmap/rest-api/files/8418387/test.docx)

